### PR TITLE
[mmark] use xml2rfc v3 syntax

### DIFF
--- a/draft-vandijk-dprive-ds-dot-signal-and-pin/Makefile
+++ b/draft-vandijk-dprive-ds-dot-signal-and-pin/Makefile
@@ -24,7 +24,7 @@ clean:
 	xml2rfc --html -o $@ $<
 
 %.xml: %.md
-	mmark -2 < $< > $@
+	mmark  < $< > $@
 
 clean:
 	rm -f draft-*.txt draft-*.html draft-*.xml


### PR DESCRIPTION
mmark -2 switch is not available on master (and since
[v2.2.0](https://github.com/mmarkdown/mmark/compare/v2.1.1...v2.2.0)) anymore.
It was removed as part of mmarkdown/mmark#97

Before:
```
Makefile:30: warning: overriding commands for target `clean'
Makefile:18: warning: ignoring old commands for target `clean'
mmark -2 < draft-vandijk-dprive-ds-dot-signal-and-pin.md > draft-vandijk-dprive-ds-dot-signal-and-pin.xml
flag provided but not defined: -2
SYNOPSIS: mmark [OPTIONS] [FILE...]
  -ast
    	print abstract syntax tree and exit
  -bibliography
    	generate a bibliography section after the back matter (default true)
  -css string
    	link to a CSS stylesheet (only used with -html)
  -fragment
    	don't create a full document
  -head string
    	link to HTML to be included in head (only used with -html)
  -html
    	create HTML output
  -index
    	generate an index at the end of the document (default true)
  -man
    	generate manual pages (nroff)
  -markdown
    	generate markdown (experimental)
  -unsafe
    	allow unsafe includes
  -version
    	show mmark version
  -w	write to source file when generating markdown
  -width int
    	text width when generating markdown (default 100)
make: *** [draft-vandijk-dprive-ds-dot-signal-and-pin.xml] Error 2
rm draft-vandijk-dprive-ds-dot-signal-and-pin.xml
```

After:
```
Makefile:30: warning: overriding commands for target `clean'
Makefile:18: warning: ignoring old commands for target `clean'
mmark  < draft-vandijk-dprive-ds-dot-signal-and-pin.md > draft-vandijk-dprive-ds-dot-signal-and-pin.xml
xml2rfc --text -o draft-vandijk-dprive-ds-dot-signal-and-pin.txt draft-vandijk-dprive-ds-dot-signal-and-pin.xml
draft-vandijk-dprive-ds-dot-signal-and-pin.xml(3): Warning: The 'docName' attribute of the <rfc/> element should have a revision number as the last component: docName="draft-foo-bar-02".
 Created file draft-vandijk-dprive-ds-dot-signal-and-pin.txt
rm draft-vandijk-dprive-ds-dot-signal-and-pin.xml
```